### PR TITLE
[nightshift] readme-improvements: automated README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,63 @@
 # kagi-mcp
 
-`kagi-mcp` is a tiny MCP server built on top of [`kagi-cli`](https://github.com/Microck/kagi-cli).
+[![Crates.io](https://img.shields.io/crates/v/kagi-mcp)](https://crates.io/crates/kagi-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/Rust-1.85+-dea584.svg?logo=rust)](https://www.rust-lang.org)
 
-It is intentionally just an extra repo:
+`kagi-mcp` is a tiny MCP server that provides access to [Kagi](https://kagi.com) search and AI services through the Model Context Protocol. It wraps the [`kagi-cli`](https://github.com/Microck/kagi-cli) to offer search, summarization, translation, assistant interactions, and more to MCP clients like Claude Desktop, Zed, and others.
 
-- separate repo
-- one Rust binary
-- wraps the `kagi` CLI instead of reimplementing Kagi logic
-- returns the same JSON the CLI already emits
+## Why a Separate Repo?
+
+This project is intentionally separate from `kagi-cli`:
+
+- Single Rust binary, easy to distribute
+- Wraps the `kagi` CLI instead of reimplementing Kagi logic
+- Returns the same JSON the CLI already emits
+- Minimal dependencies, focused on MCP protocol handling
 
 ## Requirements
 
 - A working `kagi` binary on `PATH`, or `KAGI_CLI_PATH` pointing to it
 - Kagi credentials provided through environment variables
-  - `KAGI_SESSION_TOKEN` — for subscriber features (search, quick, assistant, translate, etc.)
-  - `KAGI_API_TOKEN` — for paid API features (summarize, fastgpt, enrich)
+- `KAGI_SESSION_TOKEN` — for subscriber features (search, quick, assistant, translate, etc.)
+- `KAGI_API_TOKEN` — for paid API features (summarize, fastgpt, enrich)
 
-`.kagi.toml` is not the recommended auth path for MCP usage because the CLI resolves it relative to the server process working directory.
+> **Note:** `.kagi.toml` is not the recommended auth path for MCP usage because the CLI resolves it relative to the server process working directory.
+
+### Getting Your Tokens
+
+1. **Session Token** (subscriber features): Available in your [Kagi account settings](https://kagi.com/settings)
+2. **API Token** (paid API features): Generate in your [Kagi developer settings](https://kagi.com/settings?tab=developer)
+
+## Features
+
+- **Search** — Full-text web search with filters (lens, region, time, ordering)
+- **Quick Answer** — Direct answers with source citations
+- **Assistant** — Conversational AI with thread management
+- **Summarize** — URL or text summarization (subscriber or API mode)
+- **Translate** — Auto-detect language, alternatives, word-level insights
+- **News** — Kagi News by category, including chaos index
+- **Enrichment** — Web and news enrichment queries
+- **FastGPT** — Quick factual answers via paid API
+- **Small Web** — Curated small web feed
+
+## Install kagi-cli
+
+The server requires the `kagi` CLI to be installed. Install it via:
+
+```bash
+# Using Cargo
+cargo install kagi-cli
+
+# Or download pre-built binaries from the releases page
+# https://github.com/Microck/kagi-cli/releases
+```
+
+Verify the installation:
+
+```bash
+kagi --version
+```
 
 ## Build
 
@@ -42,9 +83,30 @@ Optional environment variables:
 
 ## Claude Desktop
 
+Add the following to your Claude Desktop config file (`claude_desktop_config.json`):
+
 ```json
 {
   "mcpServers": {
+    "kagi": {
+      "command": "/path/to/kagi-mcp/target/release/kagi-mcp",
+      "env": {
+        "KAGI_CLI_PATH": "/path/to/kagi",
+        "KAGI_SESSION_TOKEN": "your-session-token",
+        "KAGI_API_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+### Zed
+
+Add to your Zed `settings.json`:
+
+```json
+{
+  "model_context_providers": {
     "kagi": {
       "command": "/path/to/kagi-mcp/target/release/kagi-mcp",
       "env": {


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** readme-improvements
**Category:** pr
**Changes:** Improved README.md with badges for crates.io, MIT license, and Rust version. Added Features overview section listing all capabilities. Added kagi-cli installation instructions with cargo install and release download options plus verification step. Added Zed configuration example. Added token acquisition instructions with links to Kagi settings. Improved section headings and clarified the 'Why a Separate Repo' section.

Merge if useful, close if not.